### PR TITLE
[WIP] Serial: possible bugfixes

### DIFF
--- a/otbox.py
+++ b/otbox.py
@@ -483,6 +483,7 @@ class OtBox(object):
                         break
                     else:
                         self.logger.debug("No EUI64 found in '%s'", line)
+                ser.close()
 
         for e in self.motesinfo:
             if 'EUI64' in e:
@@ -593,6 +594,7 @@ class OtBox(object):
         mote       = self._eui64_to_moteinfoelem(deviceId)
         serialHandler = serial.Serial(mote['serialport'], baudrate=self.tb.baudrate, xonxoff=True)
         serialHandler.write(bytearray(payload['serialbytes']))
+        serialHandler.close()
         self.SerialportHandlers[mote['serialport']].connectSerialPort()
 
     def _mqtt_handler_reset(self, deviceType, deviceId, payload):
@@ -611,6 +613,7 @@ class OtBox(object):
         pyserialHandler.setRTS(False)
         time.sleep(0.2)
         pyserialHandler.setDTR(False)
+        pyserialHandler.close()
 
         ## start serial
         self.SerialportHandlers[mote['serialport']].connectSerialPort()

--- a/otbox.py
+++ b/otbox.py
@@ -678,6 +678,8 @@ class OtBox(object):
 
             # record whether bootload worked or not
             returnVal += [ongoing_bootloads[ongoing_bootload].returncode== 0]
+            if not returnVal[-1]:
+                raise RuntimeError(stdout, stderr)
 
         self.logger.debug("Finished bootload_motes with returnVal %s", str(returnVal))
         return returnVal

--- a/otbox.py
+++ b/otbox.py
@@ -84,7 +84,7 @@ class OpenTestbed(Testbed):
 
         self.firmware_eui64_retrieval = os.path.join(os.path.dirname(__file__), 'bootloaders', 'opentestbed',
                                                      '01bsp_eui64_prog.ihex')
-        self.firmware_temp = os.path.join(os.path.dirname(__file__), 'bootloaders', 'opentestbed', 'firmware_mote.ihex')
+        self.firmware_temp_dir = os.path.join(os.path.dirname(__file__), 'bootloaders', 'opentestbed')
 
     def bootload_mote(self, serialport, firmware_file):
         return subprocess.Popen(
@@ -552,13 +552,24 @@ class OtBox(object):
         self.SerialportHandlers[mote['serialport']].disconnectSerialPort()
         time.sleep(2) # wait 2 seconds to release the serial ports
         
+        if isinstance(self.tb, OpenTestbed):
+            # For OpenTestbed, we will use a separate firmware_temp
+            # for each deviceId. Although other testbeds may need to
+            # do the same, we keep the original implementation for
+            # them for now.
+            firmware_name = '{0}_{1}'.format(deviceId, payload['description'])
+            firmware_temp = os.path.join(self.tb.firmware_temp_dir,
+                                         firmware_name)
+        else:
+            firmware_temp = self.tb.firmware_temp
+
         if 'url' in payload and payload['url'].startswith("ftp://"):
             # use urllib to get firmware from ftp server (requests doesn't support for ftp)
-            urllib.urlretrieve(payload['url'],self.tb.firmware_temp)
+            urllib.urlretrieve(payload['url'],firmware_temp)
             urllib.urlcleanup()
         else:
             # store the firmware to load into a temporary file
-            with open(self.tb.firmware_temp, 'wb') as f:
+            with open(firmware_temp, 'wb') as f:
                 if 'url' in payload: # download file from url if present
                     file   = requests.get(payload['url'], allow_redirects=True)
                     f.write(file.content)
@@ -571,7 +582,7 @@ class OtBox(object):
         # bootload the mote
         bootload_success = self._bootload_motes(
             serialports      = [mote['serialport']],
-            firmware_file    = self.tb.firmware_temp,
+            firmware_file    = firmware_temp,
         )
 
         assert len(bootload_success)==1

--- a/otbox.py
+++ b/otbox.py
@@ -654,13 +654,13 @@ class OtBox(object):
 
     def _heartbeatthread_func(self):
         while True:
-            # wait a bit
-            time.sleep(OtBox.HEARTBEAT_PERIOD)
             # publish a heartbeat message
             self.mqttclient.publish(
                 topic   = '{0}/heartbeat'.format(self.mqtttopic_box_notif_prefix),
                 payload = json.dumps({'software_version': OTBOX_VERSION}),
             )
+            # wait a bit
+            time.sleep(OtBox.HEARTBEAT_PERIOD)
 
     #=== helpers
 

--- a/otbox.py
+++ b/otbox.py
@@ -548,9 +548,11 @@ class OtBox(object):
         payload    = json.loads(payload) # shorthand
         mote       = self._eui64_to_moteinfoelem(deviceId)
         
+        # reset the mote first
+        self._mqtt_handler_reset(deviceType, deviceId, payload=None)
+
         # disconnect from the serialports
         self.SerialportHandlers[mote['serialport']].disconnectSerialPort()
-        time.sleep(2) # wait 2 seconds to release the serial ports
         
         if isinstance(self.tb, OpenTestbed):
             # For OpenTestbed, we will use a separate firmware_temp

--- a/otbox.py
+++ b/otbox.py
@@ -171,11 +171,7 @@ class IotLabTestbed(Testbed):
                                                        stderr=subprocess.PIPE)
 
     def on_mqtt_connect(self):
-        # in case of IoT-LAB mote discovery is started immediately upon `otbox.py` startup
-        payload_status = {
-            'token': 123
-        }
-        self._otbox._mqtt_handler_discovermotes('box', 'all', json.dumps(payload_status))
+        pass
 
 class WilabTestbed(Testbed):
 
@@ -202,11 +198,7 @@ class WilabTestbed(Testbed):
         return subprocess.Popen(cmd,   stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     def on_mqtt_connect(self):
-        # in case of WiLab mote discovery is started immediately upon `otbox.py` startup
-        payload_status = {
-            'token': 123
-        }
-        self._otbox._mqtt_handler_discovermotes('box', 'all', json.dumps(payload_status))
+        pass
 
 
 AVAILABLE_TESTBEDS = {
@@ -307,6 +299,8 @@ class OtBox(object):
 
         self.tb.on_mqtt_connect()
 
+        # discover motes
+        self._excecute_command_safely('box', 'all', json.dumps({'token': 123}), 'discovermotes')
 
     def _on_mqtt_message(self, client, userdata, message):
 

--- a/otbox.py
+++ b/otbox.py
@@ -300,14 +300,14 @@ class OtBox(object):
         self.tb.on_mqtt_connect()
 
         # discover motes
-        self._excecute_command_safely('box', 'all', json.dumps({'token': 123}), 'discovermotes')
+        self._execute_command_safely('box', 'all', json.dumps({'token': 123}), 'discovermotes')
 
     def _on_mqtt_message(self, client, userdata, message):
 
         # call the handler
-        self._excecute_commands(message.topic, message.payload)
+        self._execute_commands(message.topic, message.payload)
 
-    def _excecute_commands(self, topic, payload):
+    def _execute_commands(self, topic, payload):
         # parse the topic to extract deviceType, deviceId and cmd ([0-9\-]+)
         try:
             m = re.search('{0}/deviceType/([a-z]+)/deviceId/([\w,\-]+)/cmd/([a-z]+)'.format(self.testbed), topic)
@@ -336,7 +336,7 @@ class OtBox(object):
             for d in device_to_comand:
                 commands_handlers     += [threading.Thread(
                                 name   = '{0}_command_{1}'.format(d, cmd),
-                                target = self._excecute_command_safely,
+                                target = self._execute_command_safely,
                                 args   = (deviceType, d, payload, cmd))
                                             ]
             for handler in commands_handlers:
@@ -344,7 +344,7 @@ class OtBox(object):
         except:
             self.logger.exception("Could not parse command with topic %s", topic)
 
-    def _excecute_command_safely(self, deviceType, deviceId, payload, cmd):
+    def _execute_command_safely(self, deviceType, deviceId, payload, cmd):
         '''
         Executes the handler of a command in a try/except environment so exception doesn't crash server.
         '''


### PR DESCRIPTION
I experienced a low (not perfect) success rate of flashing a firmware through OpenTestbed. And, I found the software flow control is not enabled in  `cc2538-bsp.py`. Since the latest OpenWSN-FW expects the software flow control is enabled on the other end of the UART connection, I believe `cc2538-bsp.py` should enable it.

This PR sets `True` to `xonxoff` option of `serial.Serial()` constructor. In addition, this PR adds some missing `close()` calls, which I think should be called...

Note that these changes are not tested because I don't have access to physical otboxes.