### PR TITLE
Fix Issue #102

### DIFF
--- a/otbox.py
+++ b/otbox.py
@@ -483,6 +483,7 @@ class OtBox(object):
                         break
                     else:
                         self.logger.debug("No EUI64 found in '%s'", line)
+                ser.close()
 
         for e in self.motesinfo:
             if 'EUI64' in e:
@@ -593,6 +594,7 @@ class OtBox(object):
         mote       = self._eui64_to_moteinfoelem(deviceId)
         serialHandler = serial.Serial(mote['serialport'], baudrate=self.tb.baudrate, xonxoff=True)
         serialHandler.write(bytearray(payload['serialbytes']))
+        serialHandler.close()
         self.SerialportHandlers[mote['serialport']].connectSerialPort()
 
     def _mqtt_handler_reset(self, deviceType, deviceId, payload):
@@ -611,6 +613,7 @@ class OtBox(object):
         pyserialHandler.setRTS(False)
         time.sleep(0.2)
         pyserialHandler.setDTR(False)
+        pyserialHandler.close()
 
         ## start serial
         self.SerialportHandlers[mote['serialport']].connectSerialPort()

--- a/otbox.py
+++ b/otbox.py
@@ -678,6 +678,8 @@ class OtBox(object):
 
             # record whether bootload worked or not
             returnVal += [ongoing_bootloads[ongoing_bootload].returncode== 0]
+            if not returnVal[-1]:
+                raise RuntimeError(stdout, stderr)
 
         self.logger.debug("Finished bootload_motes with returnVal %s", str(returnVal))
         return returnVal

--- a/otbox.py
+++ b/otbox.py
@@ -84,7 +84,7 @@ class OpenTestbed(Testbed):
 
         self.firmware_eui64_retrieval = os.path.join(os.path.dirname(__file__), 'bootloaders', 'opentestbed',
                                                      '01bsp_eui64_prog.ihex')
-        self.firmware_temp = os.path.join(os.path.dirname(__file__), 'bootloaders', 'opentestbed', 'firmware_mote.ihex')
+        self.firmware_temp_dir = os.path.join(os.path.dirname(__file__), 'bootloaders', 'opentestbed')
 
     def bootload_mote(self, serialport, firmware_file):
         return subprocess.Popen(
@@ -552,13 +552,24 @@ class OtBox(object):
         self.SerialportHandlers[mote['serialport']].disconnectSerialPort()
         time.sleep(2) # wait 2 seconds to release the serial ports
         
+        if isinstance(self.tb, OpenTestbed):
+            # For OpenTestbed, we will use a separate firmware_temp
+            # for each deviceId. Although other testbeds may need to
+            # do the same, we keep the original implementation for
+            # them for now.
+            firmware_name = '{0}_{1}'.format(deviceId, payload['description'])
+            firmware_temp = os.path.join(self.tb.firmware_temp_dir,
+                                         firmware_name)
+        else:
+            firmware_temp = self.tb.firmware_temp
+
         if 'url' in payload and payload['url'].startswith("ftp://"):
             # use urllib to get firmware from ftp server (requests doesn't support for ftp)
-            urllib.urlretrieve(payload['url'],self.tb.firmware_temp)
+            urllib.urlretrieve(payload['url'],firmware_temp)
             urllib.urlcleanup()
         else:
             # store the firmware to load into a temporary file
-            with open(self.tb.firmware_temp, 'wb') as f:
+            with open(firmware_temp, 'wb') as f:
                 if 'url' in payload: # download file from url if present
                     file   = requests.get(payload['url'], allow_redirects=True)
                     f.write(file.content)
@@ -571,7 +582,7 @@ class OtBox(object):
         # bootload the mote
         bootload_success = self._bootload_motes(
             serialports      = [mote['serialport']],
-            firmware_file    = self.tb.firmware_temp,
+            firmware_file    = firmware_temp,
         )
 
         assert len(bootload_success)==1

--- a/otbox.py
+++ b/otbox.py
@@ -654,13 +654,13 @@ class OtBox(object):
 
     def _heartbeatthread_func(self):
         while True:
-            # wait a bit
-            time.sleep(OtBox.HEARTBEAT_PERIOD)
             # publish a heartbeat message
             self.mqttclient.publish(
                 topic   = '{0}/heartbeat'.format(self.mqtttopic_box_notif_prefix),
                 payload = json.dumps({'software_version': OTBOX_VERSION}),
             )
+            # wait a bit
+            time.sleep(OtBox.HEARTBEAT_PERIOD)
 
     #=== helpers
 

--- a/otbox.py
+++ b/otbox.py
@@ -548,9 +548,11 @@ class OtBox(object):
         payload    = json.loads(payload) # shorthand
         mote       = self._eui64_to_moteinfoelem(deviceId)
         
+        # reset the mote first
+        self._mqtt_handler_reset(deviceType, deviceId, payload=None)
+
         # disconnect from the serialports
         self.SerialportHandlers[mote['serialport']].disconnectSerialPort()
-        time.sleep(2) # wait 2 seconds to release the serial ports
         
         if isinstance(self.tb, OpenTestbed):
             # For OpenTestbed, we will use a separate firmware_temp

--- a/otbox.py
+++ b/otbox.py
@@ -171,11 +171,7 @@ class IotLabTestbed(Testbed):
                                                        stderr=subprocess.PIPE)
 
     def on_mqtt_connect(self):
-        # in case of IoT-LAB mote discovery is started immediately upon `otbox.py` startup
-        payload_status = {
-            'token': 123
-        }
-        self._otbox._mqtt_handler_discovermotes('box', 'all', json.dumps(payload_status))
+        pass
 
 class WilabTestbed(Testbed):
 
@@ -202,11 +198,7 @@ class WilabTestbed(Testbed):
         return subprocess.Popen(cmd,   stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     def on_mqtt_connect(self):
-        # in case of WiLab mote discovery is started immediately upon `otbox.py` startup
-        payload_status = {
-            'token': 123
-        }
-        self._otbox._mqtt_handler_discovermotes('box', 'all', json.dumps(payload_status))
+        pass
 
 
 AVAILABLE_TESTBEDS = {
@@ -307,6 +299,8 @@ class OtBox(object):
 
         self.tb.on_mqtt_connect()
 
+        # discover motes
+        self._excecute_command_safely('box', 'all', json.dumps({'token': 123}), 'discovermotes')
 
     def _on_mqtt_message(self, client, userdata, message):
 

--- a/otbox.py
+++ b/otbox.py
@@ -300,14 +300,14 @@ class OtBox(object):
         self.tb.on_mqtt_connect()
 
         # discover motes
-        self._excecute_command_safely('box', 'all', json.dumps({'token': 123}), 'discovermotes')
+        self._execute_command_safely('box', 'all', json.dumps({'token': 123}), 'discovermotes')
 
     def _on_mqtt_message(self, client, userdata, message):
 
         # call the handler
-        self._excecute_commands(message.topic, message.payload)
+        self._execute_commands(message.topic, message.payload)
 
-    def _excecute_commands(self, topic, payload):
+    def _execute_commands(self, topic, payload):
         # parse the topic to extract deviceType, deviceId and cmd ([0-9\-]+)
         try:
             m = re.search('{0}/deviceType/([a-z]+)/deviceId/([\w,\-]+)/cmd/([a-z]+)'.format(self.testbed), topic)
@@ -336,7 +336,7 @@ class OtBox(object):
             for d in device_to_comand:
                 commands_handlers     += [threading.Thread(
                                 name   = '{0}_command_{1}'.format(d, cmd),
-                                target = self._excecute_command_safely,
+                                target = self._execute_command_safely,
                                 args   = (deviceType, d, payload, cmd))
                                             ]
             for handler in commands_handlers:
@@ -344,7 +344,7 @@ class OtBox(object):
         except:
             self.logger.exception("Could not parse command with topic %s", topic)
 
-    def _excecute_command_safely(self, deviceType, deviceId, payload, cmd):
+    def _execute_command_safely(self, deviceType, deviceId, payload, cmd):
         '''
         Executes the handler of a command in a try/except environment so exception doesn't crash server.
         '''


### PR DESCRIPTION
This PR introduces two changes for Issue #102:

* create a separate firmware file for each mote (applied only to `--testbed=opentestbed` case)
* reset a mote before programming

When programming motes one by one with a certain interval, `cc2538-bsl.py` fails saying "Timeout waiting for ACK/NACK after 'Synch (0x55 0x55)'". I suspected that the serial port was not cleanly released when `cc2538-bsl.py` started, but seems this is not true.

After some trial-and-error iterations, I found resetting a mote just before programming gives better success rate for programming.

Here are logs of my script after adding `reset()` to `_mqtt_handler_program():
```
2019-06-03 16:41:11,516: [INFO] Start programming "openwsn-openmote-b-24ghz.ihex" to 00-12-4b-00-14-b5-b5-77
2019-06-03 16:41:14,521: [INFO] Start programming "openwsn-openmote-b-24ghz.ihex" to 00-12-4b-00-14-b5-b5-9b
2019-06-03 16:41:17,524: [INFO] Start programming "openwsn-openmote-b-24ghz.ihex" to 00-12-4b-00-14-b5-b6-06
2019-06-03 16:41:20,529: [INFO] Start programming "openwsn-openmote-b-24ghz.ihex" to 00-12-4b-00-14-b5-b6-30
2019-06-03 16:41:24,693: [INFO] Succeed to program "openwsn-openmote-b-24ghz.ihex" to 00-12-4b-00-14-b5-b5-77
2019-06-03 16:41:27,523: [INFO] Succeed to program "openwsn-openmote-b-24ghz.ihex" to 00-12-4b-00-14-b5-b5-9b
2019-06-03 16:41:30,670: [INFO] Succeed to program "openwsn-openmote-b-24ghz.ihex" to 00-12-4b-00-14-b5-b6-06
2019-06-03 16:41:33,290: [INFO] Succeed to program "openwsn-openmote-b-24ghz.ihex" to 00-12-4b-00-14-b5-b6-30
```

Without `reset()`, programing failed 3 out of 4:
```
2019-06-03 16:36:54,014: [INFO] Start programming "openwsn-openmote-b-24ghz.ihex" to 00-12-4b-00-14-b5-b5-77
2019-06-03 16:36:57,018: [INFO] Start programming "openwsn-openmote-b-24ghz.ihex" to 00-12-4b-00-14-b5-b5-9b
2019-06-03 16:37:00,021: [INFO] Start programming "openwsn-openmote-b-24ghz.ihex" to 00-12-4b-00-14-b5-b6-06
2019-06-03 16:37:03,026: [INFO] Start programming "openwsn-openmote-b-24ghz.ihex" to 00-12-4b-00-14-b5-b6-30
2019-06-03 16:37:03,099: [ERROR] Failed to program "openwsn-openmote-b-24ghz.ihex" to 00-12-4b-00-14-b5-b5-9b
2019-06-03 16:37:06,010: [ERROR] Failed to program "openwsn-openmote-b-24ghz.ihex" to 00-12-4b-00-14-b5-b6-06
2019-06-03 16:37:09,045: [INFO] Succeed to program "openwsn-openmote-b-24ghz.ihex" to 00-12-4b-00-14-b5-b5-77
2019-06-03 16:37:09,072: [ERROR] Failed to program "openwsn-openmote-b-24ghz.ihex" to 00-12-4b-00-14-b5-b6-30

```

This PR has other minor improvements as well. 